### PR TITLE
Add event processing queue

### DIFF
--- a/ParselyDemo.xcodeproj/project.pbxproj
+++ b/ParselyDemo.xcodeproj/project.pbxproj
@@ -366,6 +366,7 @@
 				F433339220F0087E004BB6F5 /* Sources */,
 				F433339320F0087E004BB6F5 /* Frameworks */,
 				F433339420F0087E004BB6F5 /* Resources */,
+				50A891132731B54A9972347D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -462,6 +463,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		50A891132731B54A9972347D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ParselyTrackerTests/Pods-ParselyTrackerTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ParselyTrackerTests/Pods-ParselyTrackerTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		96272734BE9824902EF80C99 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/ParselyTracker/HttpClient.swift
+++ b/ParselyTracker/HttpClient.swift
@@ -2,7 +2,7 @@ import Foundation
 import os.log
 
 class HttpClient {
-    static func sendRequest(request: ParselyRequest, completion: ((Error?) -> Void)? = nil) {
+    static func sendRequest(request: ParselyRequest, queue: DispatchQueue, completion: ((Error?) -> Void)? = nil) {
         os_log("Sending request to %s", log: OSLog.tracker, type: .debug, request.url)
         
         guard let url = URL(string: request.url) else {
@@ -28,7 +28,9 @@ class HttpClient {
                 os_log("Request succeeded", log: OSLog.tracker, type: .debug)
             }
 
-            completion?(error)
+            queue.async {
+                completion?(error)
+            }
         }.resume()
     }
 }

--- a/ParselyTracker/ParselyTracker.swift
+++ b/ParselyTracker/ParselyTracker.swift
@@ -255,6 +255,7 @@ public class Parsely {
 
     private func addApplicationObservers() {
         let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
         queue.underlyingQueue = eventProcessor
         NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: queue, using: self.resumeExecution(_:))
         NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: queue, using: self.resumeExecution(_:))

--- a/ParselyTracker/ParselyTracker.swift
+++ b/ParselyTracker/ParselyTracker.swift
@@ -227,7 +227,7 @@ public class Parsely {
         let events = eventQueue.get()
         os_log("Got %s events", log: OSLog.tracker, type:.debug, String(describing: events.count))
         let request = RequestBuilder.buildRequest(events: events)
-        HttpClient.sendRequest(request: request!) { error in
+        HttpClient.sendRequest(request: request!, queue: eventProcessor) { error in
             if let error = error as? URLError, error.code == .notConnectedToInternet {
                 // When offline, return the events to the queue for the next flush().
                 self.eventQueue.push(contentsOf: events)

--- a/ParselyTracker/ParselyTracker.swift
+++ b/ParselyTracker/ParselyTracker.swift
@@ -251,11 +251,13 @@ public class Parsely {
     }
 
     private func addApplicationObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(resumeExecution(_:)), name: UIApplication.didBecomeActiveNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(resumeExecution(_:)), name: UIApplication.willEnterForegroundNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(suspendExecution(_:)), name: UIApplication.willResignActiveNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(suspendExecution(_:)), name: UIScene.didEnterBackgroundNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(suspendExecution(_:)), name: UIApplication.willTerminateNotification, object: nil)
+        let queue = OperationQueue()
+        queue.underlyingQueue = eventProcessor
+        NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: queue, using: self.resumeExecution(_:))
+        NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: queue, using: self.resumeExecution(_:))
+        NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: queue, using: self.suspendExecution(_:))
+        NotificationCenter.default.addObserver(forName: UIScene.didEnterBackgroundNotification, object: nil, queue: queue, using: self.suspendExecution(_:))
+        NotificationCenter.default.addObserver(forName: UIApplication.willTerminateNotification, object: nil, queue: queue, using: self.suspendExecution(_:))
     }
 
     @objc private func resumeExecution(_ notification: Notification) {

--- a/ParselyTracker/ParselyTracker.swift
+++ b/ParselyTracker/ParselyTracker.swift
@@ -21,6 +21,10 @@ public class Parsely {
         return _track
     }
     var eventQueue: EventQueue<Event> = EventQueue()
+    // All tracker related state should be modified in this serial queue, to ensure thread-safty.
+    // This property is declared as internal rather than private, because we need to use it to make sure
+    // unit tests that inspect tracker's internal state can pass reliably.
+    var eventProcessor: DispatchQueue
     internal static let sharedStorage = Storage()
     lazy var visitorManager = VisitorManager()
     internal static func getInstance() -> Parsely {
@@ -33,7 +37,6 @@ public class Parsely {
     private var flushInterval: TimeInterval = 30
     private var backgroundFlushTask: UIBackgroundTaskIdentifier = .invalid
     private var active: Bool = true
-    private var eventProcessor: DispatchQueue
 
     private init() {
         os_log("Initializing ParselyTracker", log: OSLog.tracker, type: .info)

--- a/ParselyTracker/ParselyTracker.swift
+++ b/ParselyTracker/ParselyTracker.swift
@@ -277,17 +277,14 @@ public class Parsely {
         self.active = false
         os_log("Stopping execution before background/inactive/terminate", log:OSLog.tracker, type:.info)
         hardShutdown()
-        
-        DispatchQueue.global(qos: .userInitiated).async{
-            let _self = self
-            _self.backgroundFlushTask = UIApplication.shared.beginBackgroundTask(expirationHandler:{
-                _self.endBackgroundFlushTask()
-            })
-            os_log("Flushing queue in background", log:OSLog.tracker, type:.info)
-            _self.track.sendHeartbeats()
-            _self.flush()
-            _self.endBackgroundFlushTask()
-        }
+
+        self.backgroundFlushTask = UIApplication.shared.beginBackgroundTask(expirationHandler:{
+            self.endBackgroundFlushTask()
+        })
+        os_log("Flushing queue in background", log:OSLog.tracker, type:.info)
+        self.track.sendHeartbeats()
+        self.flush()
+        self.endBackgroundFlushTask()
     }
     
     internal func hardShutdown() {

--- a/ParselyTrackerTests/ParselyTrackerTests.swift
+++ b/ParselyTrackerTests/ParselyTrackerTests.swift
@@ -47,7 +47,7 @@ class ParselyTrackerTests: ParselyTestCase {
         expectParselyState(self.parselyTestTracker.track.videoManager.trackedVideos.count).toEventually(equal(1))
 
         XCTAssertEqual(parselyTestTracker.eventQueue.length(), 1, "A call to Parsely.trackPlay should add an event to eventQueue")
-        try XCTAssert(
+        try XCTAssertTrue(
             XCTUnwrap(parselyTestTracker.track.videoManager.trackedVideos.values.first).isPlaying,
             "After a call to Parsely.trackPlay, the tracked video should have its isPlaying flag set"
         )
@@ -71,7 +71,7 @@ class ParselyTrackerTests: ParselyTestCase {
         expectParselyState(self.parselyTestTracker.track.videoManager.trackedVideos.isEmpty).toEventually(beFalse())
 
         parselyTestTracker.resetVideo(url: testUrl, videoID: testVideoId)
-        // A call to Parsely.resetVideo should remove an tracked video from the video manager
+        // A call to Parsely.resetVideo should remove a tracked video from the video manager
         expectParselyState(self.parselyTestTracker.track.videoManager.trackedVideos.isEmpty).toEventually(beTrue())
     }
 

--- a/ParselyTrackerTests/ParselyTrackerTests.swift
+++ b/ParselyTrackerTests/ParselyTrackerTests.swift
@@ -22,72 +22,57 @@ class ParselyTrackerTests: ParselyTestCase {
         XCTAssertEqual(parselyTestTracker.eventQueue.length(), 0,
                        "eventQueue should be empty immediately after initialization")
         parselyTestTracker.trackPageView(url: testUrl, urlref: testUrl, metadata: nil, extraData: nil)
+        // A call to Parsely.trackPageView should add an event to eventQueue
         expectParselyState(self.parselyTestTracker.eventQueue.length()).toEventually(equal(1))
-        XCTAssertEqual(parselyTestTracker.eventQueue.length(), 1,
-                       "A call to Parsely.trackPageView should add an event to eventQueue")
     }
     
     func testStartEngagement() {
         parselyTestTracker.startEngagement(url: testUrl)
-        expectParselyState(self.parselyTestTracker.track.engagedTime.accumulators[self.testUrl]).toEventuallyNot(beNil())
-
-        let internalAccumulators:Dictionary<String, Accumulator> = parselyTestTracker.track.engagedTime.accumulators
-        let testUrlAccumulator: Accumulator = internalAccumulators[testUrl]!
-        XCTAssert(testUrlAccumulator.isEngaged,
-                  "After a call to Parsely.startEngagement, the internal accumulator for the engaged url should exist " +
-                  "and its isEngaged flag should be set")
+        // After a call to Parsely.startEngagement, the internal accumulator for the engaged url should exist
+        // and its isEngaged flag should be set
+        expectParselyState(self.parselyTestTracker.track.engagedTime.accumulators[self.testUrl]?.isEngaged).toEventually(beTrue())
     }
     func testStopEngagement() {
         parselyTestTracker.startEngagement(url: testUrl)
-
         expectParselyState(self.parselyTestTracker.track.engagedTime.accumulators[self.testUrl]).toEventuallyNot(beNil())
 
         parselyTestTracker.stopEngagement()
+        // After a call to Parsely.startEngagement followed by a call to Parsely.stopEngagement, the internal
+        // accumulator for the engaged url should exist and its isEngaged flag should be unset
         expectParselyState(self.parselyTestTracker.track.engagedTime.accumulators[self.testUrl]?.isEngaged).toEventually(beFalse())
-
-        let internalAccumulators:Dictionary<String, Accumulator> = parselyTestTracker.track.engagedTime.accumulators
-        let testUrlAccumulator: Accumulator = internalAccumulators[testUrl]!
-        XCTAssertFalse(testUrlAccumulator.isEngaged,
-                  "After a call to Parsely.startEngagement followed by a call to Parsely.stopEngagement, the internal " +
-                  "accumulator for the engaged url should exist and its isEngaged flag should be unset")
     }
-    func testTrackPlay() {
+    func testTrackPlay() throws {
         parselyTestTracker.trackPlay(url: testUrl, videoID: testVideoId, duration: TimeInterval(10))
-        expectParselyState(self.parselyTestTracker.track.videoManager.trackedVideos.isEmpty).toEventually(beFalse())
+        // After a call to parsely.trackPlay, there should be exactly one video being tracked
+        expectParselyState(self.parselyTestTracker.track.videoManager.trackedVideos.count).toEventually(equal(1))
 
-        let videoManager: VideoManager = parselyTestTracker.track.videoManager
-        let trackedVideos: Dictionary<String, TrackedVideo> = videoManager.trackedVideos
-        XCTAssertEqual(parselyTestTracker.eventQueue.length(), 1,
-                       "A call to Parsely.trackPlay should add an event to eventQueue")
-        XCTAssertEqual(trackedVideos.count, 1,
-                       "After a call to parsely.trackPlay, there should be exactly one video being tracked")
-        let testVideo: TrackedVideo = trackedVideos.values.first!
-        XCTAssert(testVideo.isPlaying,
-                  "After a call to Parsely.trackPlay, the tracked video should have its isPlaying flag set")
+        XCTAssertEqual(parselyTestTracker.eventQueue.length(), 1, "A call to Parsely.trackPlay should add an event to eventQueue")
+        try XCTAssert(
+            XCTUnwrap(parselyTestTracker.track.videoManager.trackedVideos.values.first).isPlaying,
+            "After a call to Parsely.trackPlay, the tracked video should have its isPlaying flag set"
+        )
     }
-    func testTrackPause() {
+    func testTrackPause() throws {
         parselyTestTracker.trackPlay(url: testUrl, videoID: testVideoId, duration: TimeInterval(10))
         expectParselyState(self.parselyTestTracker.track.videoManager.trackedVideos.isEmpty).toEventually(beFalse())
 
         parselyTestTracker.trackPause()
-        expectParselyState(self.parselyTestTracker.track.videoManager.trackedVideos.values.first?.isPlaying).toEventually(beFalse())
+        // After a call to parsely.trackPlay followed by a call to parsely.trackPause, there should be
+        // exactly one video being tracked
+        expectParselyState(self.parselyTestTracker.track.videoManager.trackedVideos.count).toEventually(equal(1))
 
-        let videoManager: VideoManager = parselyTestTracker.track.videoManager
-        let trackedVideos: Dictionary<String, TrackedVideo> = videoManager.trackedVideos
-        XCTAssertEqual(trackedVideos.count, 1,
-                       "After a call to parsely.trackPlay followed by a call to parsely.trackPause, there should be " +
-                       "exactly one video being tracked")
-        let testVideo: TrackedVideo = trackedVideos.values.first!
-        XCTAssertFalse(testVideo.isPlaying,
-                       "After a call to Parsely.trackPlay, the tracked video should have its isPlaying flag unset")
+        try XCTAssertFalse(
+            XCTUnwrap(parselyTestTracker.track.videoManager.trackedVideos.values.first).isPlaying,
+            "After a call to Parsely.trackPlay, the tracked video should have its isPlaying flag unset"
+        )
     }
     func testResetVideo() {
         parselyTestTracker.trackPlay(url: testUrl, videoID: testVideoId, duration: TimeInterval(10))
+        expectParselyState(self.parselyTestTracker.track.videoManager.trackedVideos.isEmpty).toEventually(beFalse())
+
         parselyTestTracker.resetVideo(url: testUrl, videoID: testVideoId)
-        let videoManager: VideoManager = parselyTestTracker.track.videoManager
-        let trackedVideos: Dictionary<String, TrackedVideo> = videoManager.trackedVideos
-        XCTAssertEqual(trackedVideos.count, 0,
-                       "A call to Parsely.resetVideo should remove an tracked video from the video manager")
+        // A call to Parsely.resetVideo should remove an tracked video from the video manager
+        expectParselyState(self.parselyTestTracker.track.videoManager.trackedVideos.isEmpty).toEventually(beTrue())
     }
 
     // A helper method to safely inspect the tracker's internal state.

--- a/Podfile
+++ b/Podfile
@@ -14,6 +14,7 @@ abstract_target 'Parsely' do
   target 'ParselyTracker' do
     target 'ParselyTrackerTests' do
       inherit! :search_paths
+      pod 'Nimble'
     end
   end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,20 @@
 PODS:
+  - Nimble (11.2.2)
   - SwiftyJSON (4.2.0)
 
 DEPENDENCIES:
+  - Nimble
   - SwiftyJSON (~> 4.2)
 
 SPEC REPOS:
   trunk:
+    - Nimble
     - SwiftyJSON
 
 SPEC CHECKSUMS:
+  Nimble: 01a944d4d07eab73617dfd4b32ac9f7152ac34de
   SwiftyJSON: c4bcba26dd9ec7a027fc8eade48e2c911f229e96
 
-PODFILE CHECKSUM: d43acb0a20b5aedeeb491da6057c40e46c8a6b33
+PODFILE CHECKSUM: e3bb13b3b5de3cb47f43955e46ae606366996378
 
 COCOAPODS: 1.12.0


### PR DESCRIPTION
## Issue

This is an attempt to fix some crashes. Here is a part of one crash report:
```
Thread 0 Crashed:
0   libswiftCore.dylib                   0x0000000192a6a198 swift_isUniquelyReferenced_nonNull_native + 0
1   ParselyAnalytics                     0x00000001072a1b1c ParselyAnalytics.EngagedTime.endInteraction() -> () (<compiler-generated>:0)
2   ParselyAnalytics                     0x00000001072a6444 ParselyAnalytics.Parsely.stopEngagement() -> () (Track.swift:63)
```

`EngagedTime.endInteraction` and `Sampler.sendHeartbeats` are two common crash sites.

## Potential Cause

I suspect this is a concurrency issue. There is almost no guarantee of where some of the functions are executed, but most of the public APIs eventually modify the internal state like [`accumulators`](https://github.com/Parsely/AnalyticsSDK-iOS/blob/6f0ab679f0de687e09814d75acac7aee75e48e96/ParselyTracker/Sampler.swift#L34) or [`eventQueue`](https://github.com/Parsely/AnalyticsSDK-iOS/blob/6f0ab679f0de687e09814d75acac7aee75e48e96/ParselyTracker/ParselyTracker.swift#L14).

## Fix

This PR adds a serial queue as the place to modify internal state. This PR changes three kinds of code to make they run inside this serial queue:
1. All "tracking" related public APIs.
2. App lifecycle notification handlers.
3. Timer handlers.

In fact, I reproduce similar crashes in unit tests by accident. You can see the crash by checking out 3a9773b48e2989c1d7754cce679c7b55a3d95b0b and running `ParselyTrackerTests` for a few times. The crash would show up (or not) randomly in different test methods.

Originally those unit tests executed assertions on the test thread. Since these assertions inspected the tracker's internal state, there were concurrency issues here: the state was modified from the newly added serial queue, but at the same time it was read from the unit test thread. This concurrency issue is fixed by moving the unit test's assertion into the tracker serial queue, and the unit test passes reliably now.

BTW, it might be easier to review this PR commit by commit.