### PR TITLE
Switch to using `.xctestplan` to run tests

### DIFF
--- a/ParselyDemo.xcodeproj/project.pbxproj
+++ b/ParselyDemo.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		2A1F0F92460A849C17B26338 /* Storage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
 		2E14A66E8F1BB8BC158D4959 /* Pods_Parsely_ParselyTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Parsely_ParselyTracker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A80C09D1CED0319E596DBEE /* Pods_ParselyTrackerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ParselyTrackerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3FCAFC8B29E9775A00BC9360 /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
 		446CD722898871FC8DB4DE4D /* Pods-Parsely-ParselyTracker.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Parsely-ParselyTracker.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Parsely-ParselyTracker/Pods-Parsely-ParselyTracker.debug.xcconfig"; sourceTree = "<group>"; };
 		491B2BC988D8B0335724A102 /* Pods-Parsely-ParselyDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Parsely-ParselyDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-Parsely-ParselyDemo/Pods-Parsely-ParselyDemo.release.xcconfig"; sourceTree = "<group>"; };
 		510E83E973D358D695481B9E /* Pods_AnalyticsSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AnalyticsSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -301,6 +302,7 @@
 				B205889E220CB72A00476E27 /* RequestBuilderTests.swift */,
 				B2FC40BF221CC43200C70806 /* MetadataTests.swift */,
 				AA73AAAE2242C1F10089BF1D /* ParselyTestCase.swift */,
+				3FCAFC8B29E9775A00BC9360 /* UnitTests.xctestplan */,
 			);
 			path = ParselyTrackerTests;
 			sourceTree = "<group>";

--- a/ParselyDemo.xcodeproj/xcshareddata/xcschemes/ParselyDemo.xcscheme
+++ b/ParselyDemo.xcodeproj/xcshareddata/xcschemes/ParselyDemo.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1010"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -36,6 +36,12 @@
             ReferencedContainer = "container:ParselyDemo.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:ParselyTrackerTests/UnitTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/ParselyDemo.xcodeproj/xcshareddata/xcschemes/ParselyTracker.xcscheme
+++ b/ParselyDemo.xcodeproj/xcshareddata/xcschemes/ParselyTracker.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
-   version = "1.3">
+   LastUpgradeVersion = "1430"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -9,14 +9,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F40D9A5920EFF74F0030525E"
-               BuildableName = "ParselyDemo.app"
-               BlueprintName = "ParselyDemo"
+               BlueprintIdentifier = "F433338D20F0087E004BB6F5"
+               BuildableName = "ParselyTracker.framework"
+               BlueprintName = "ParselyTracker"
                ReferencedContainer = "container:ParselyDemo.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -27,20 +27,12 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F433339520F0087E004BB6F5"
-               BuildableName = "ParselyTrackerTests.xctest"
-               BlueprintName = "ParselyTrackerTests"
-               ReferencedContainer = "container:ParselyDemo.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:ParselyTrackerTests/UnitTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -52,17 +44,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F40D9A5920EFF74F0030525E"
-            BuildableName = "ParselyDemo.app"
-            BlueprintName = "ParselyDemo"
-            ReferencedContainer = "container:ParselyDemo.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -73,9 +54,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F40D9A5920EFF74F0030525E"
-            BuildableName = "ParselyDemo.app"
-            BlueprintName = "ParselyDemo"
+            BlueprintIdentifier = "F433338D20F0087E004BB6F5"
+            BuildableName = "ParselyTracker.framework"
+            BlueprintName = "ParselyTracker"
             ReferencedContainer = "container:ParselyDemo.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/ParselyTrackerTests/UnitTests.xctestplan
+++ b/ParselyTrackerTests/UnitTests.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "E74B4D5C-BD46-4E81-83E3-7FF38FC45111",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:ParselyDemo.xcodeproj",
+        "identifier" : "F433339520F0087E004BB6F5",
+        "name" : "ParselyTrackerTests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
Test plans gives us more configuration options to run tests.

This is based off the work done for #8.