### PR TITLE
Relax `testBackoff()` interval equality to a 0.05 accuracy

### DIFF
--- a/ParselyTracker/ParselyTracker.swift
+++ b/ParselyTracker/ParselyTracker.swift
@@ -212,7 +212,11 @@ public class Parsely {
     /// After given `seconds`, invoke the given target-action in the event processor queue.
     func scheduleEventProcessing(inSeconds seconds: Double, target: AnyObject, selector: Selector) -> Cancellable {
         Just(0)
-            .delay(for: .seconds(seconds), scheduler: eventProcessor)
+            // From the Apple documentation it's not clear what the default tolerance is.
+            // They have an example with a .seconds(3) delay saying "3 seconds (±0.5 seconds)".
+            // To say on the safe side, we specify a 1ms tolerance, meaning "the Delay publisher may
+            // deliver elements this much sooner or later than the interval specifies."
+            .delay(for: .seconds(seconds), tolerance: .milliseconds(1), scheduler: eventProcessor)
             .sink { _ in
                 _ = target.perform(selector)
             }

--- a/ParselyTrackerTests/SamplerTests.swift
+++ b/ParselyTrackerTests/SamplerTests.swift
@@ -64,7 +64,6 @@ class SamplerTests: ParselyTestCase {
         waitForExpectations(timeout: heartbeatDeliveryInterval, handler: nil)
         
         let actualUpdatedInterval = samplerUnderTest!.heartbeatInterval
-        let actualRoundedInterval: TimeInterval = TimeInterval(round(100 * actualUpdatedInterval) / 100)
         // This value depends on heartbeatInterval, and two magic numbers in the implementation.
         // We use the output value instead of writing out the math that computes it because doing
         // so would amount to duplicating the logic under test in the test itself.
@@ -79,7 +78,7 @@ class SamplerTests: ParselyTestCase {
         // In the context of a backoff implementation it seems acceptable to account for a few
         // hundredth of a second difference between the expected interval and the recorded one.
         XCTAssertEqual(
-            actualRoundedInterval,
+            actualUpdatedInterval,
             expectedUpdatedInterval,
             accuracy: 0.04,
             "Heartbeat interval should increase by the expected amount after a single heartbeat"

--- a/ParselyTrackerTests/SamplerTests.swift
+++ b/ParselyTrackerTests/SamplerTests.swift
@@ -62,8 +62,21 @@ class SamplerTests: ParselyTestCase {
         
         let actualUpdatedInterval = samplerUnderTest!.heartbeatInterval
         let actualRoundedInterval: TimeInterval = TimeInterval(round(100 * actualUpdatedInterval) / 100)
-        XCTAssertEqual(actualRoundedInterval, expectedUpdatedInterval,
-                  "Heartbeat interval should increase by the expected amount after a single heartbeat")
+
+        // We've seen a version of this test with strict `XCTAssertEqual` being flaky and
+        // failing with a tracked interval a few hundredth of a second different from the expected
+        // value of 13.65.
+        //
+        // See for example https://github.com/Automattic/AnalyticsSDK-iOS/pull/6#issuecomment-1508327314
+        //
+        // In the context of a backoff implementation it seems acceptable to account for a few
+        // hundredth of a second difference between the expected interval and the recorded one.
+        XCTAssertEqual(
+            actualRoundedInterval,
+            expectedUpdatedInterval,
+            accuracy: 0.04,
+            "Heartbeat interval should increase by the expected amount after a single heartbeat"
+        )
     }
 
     func testDistinctTrackedItems() {


### PR DESCRIPTION
We've seen this test being flaky and failing when the tracked interval was a few hundredth of a second different from the expected 13.65. See for example https://github.com/Automattic/AnalyticsSDK-iOS/pull/6#issuecomment-1508327314

It seems in the context of a backoff implementation we can account for a few hundredth of a second difference between the expected interval and the recorded one.

This approach look even more acceptable when we consider that `testSampleFn()` also has an accuracy range of 0.2 seconds, although implemented in a different way. See
https://github.com/Automattic/AnalyticsSDK-iOS/blob/6f0ab679f0de687e09814d75acac7aee75e48e96/ParselyTrackerTests/SamplerTests.swift#L33-L48

For what is worth, I tried updating the underlying scheduling code to use a finer grained `Stride` `delay`, both with `.milliseconds` and `.microseconds` and the test was still flaky (measured as failed attempts over 10 repetitions).

Unfortunately, the only way to test this is to checkout locally, rebase on top of our base working branch so to get a test plan, and updated the test repetition to a handful of repetitions. I used 10. Here's a before-after:

<img width="1278" alt="image" src="https://user-images.githubusercontent.com/1218433/232385801-c6bc4717-5e3e-400a-a586-251a320903e5.png">
